### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main() {
 
 	let node_id = PublicKey::from_str("NODE_ID").unwrap();
 	let node_addr = NetAddress::from_str("IP_ADDR:PORT").unwrap();
-	node.connect_open_channel(node_id, node_addr, 10000, None, false).unwrap();
+	node.connect_open_channel(node_id, node_addr, 10000, None, None, false).unwrap();
 
 	let event = node.wait_next_event();
 	println!("EVENT: {:?}", event);


### PR DESCRIPTION
Add missing channel_config argument in README example for connect_open_channel to avoid error:

```----- an argument of type `std::option::Option<ChannelConfig>` is missing```

connect_open_channel:
```
pub fn connect_open_channel(&**self**, node_id: PublicKey, address: NetAddress, channel_amount_sats: u64, push_to_counterparty_msat: Option<u64>, channel_config: Option<ChannelConfig>, announce_channel: bool) -> Result<(), Error>
```